### PR TITLE
Fix for string containing acronyms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,25 +8,25 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11.0.x
       - name: Setup .NET 5.0
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 5.0.x
       - name: Setup .NET 3.1
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 3.1.x
       - name: Restore tools
         run: dotnet tool restore
       - name: Run the build script
-        uses: cake-build/cake-action@v1
+        uses: cake-build/cake-action@v3
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -34,7 +34,7 @@ jobs:
         with:
           target: CI
       - name: Upload pre-release packages
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: packages
           path: artifacts/*.nupkg

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,25 +9,25 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11.0.x
       - name: Setup .NET 5.0
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 5.0.x
       - name: Setup .NET 3.1
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 3.1.x
       - name: Restore tools
         run: dotnet tool restore
       - name: Run the build script
-        uses: cake-build/cake-action@v1
+        uses: cake-build/cake-action@v3
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/src/Json.Formatting/SnakeCaseStringExtensions.cs
+++ b/src/Json.Formatting/SnakeCaseStringExtensions.cs
@@ -35,7 +35,7 @@ namespace O9d.Json.Formatting
                             if (i > 0 && hasNext)
                             {
                                 char nextChar = nameSpan[i + 1];
-                                if (!char.IsUpper(nextChar) && nextChar != '_')
+                                if (char.IsLower(nextChar) && nextChar != '_')
                                 {
                                     sb.Append('_');
                                 }

--- a/src/Json.Formatting/SnakeCaseStringExtensions.cs
+++ b/src/Json.Formatting/SnakeCaseStringExtensions.cs
@@ -35,7 +35,7 @@ namespace O9d.Json.Formatting
                             if (i > 0 && hasNext)
                             {
                                 char nextChar = nameSpan[i + 1];
-                                if (char.IsLower(nextChar) && nextChar != '_')
+                                if (char.IsLower(nextChar))
                                 {
                                     sb.Append('_');
                                 }

--- a/test/Json.Formatting.Tests/SnakeCaseStringExtensionsTests.cs
+++ b/test/Json.Formatting.Tests/SnakeCaseStringExtensionsTests.cs
@@ -26,11 +26,13 @@ namespace O9d.Json.Formatting.Tests
         [InlineData("already_snake_case_", "already_snake_case_ ")]
         [InlineData("is_json_property", "IsJSONProperty")]
         [InlineData("shouting_case", "SHOUTING_CASE")]
+        [InlineData("abc_test", "ABC Test")]
+        [InlineData("abc_def_test", "ABC DEF Test")]
         [InlineData("9999-12-31_t23:59:59.9999999_z", "9999-12-31T23:59:59.9999999Z")]
         [InlineData("hi!!_this_is_text._time_to_test.", "Hi!! This is text. Time to test.")]
         public static void Can_convert_to_snake_case(string expected, string input)
         {
-            Assert.Equal(input.ToSnakeCase(), expected);
+            Assert.Equal(expected, input.ToSnakeCase());
         }
     }
 }


### PR DESCRIPTION
This PR fixes an issue with strings that contain acronyms.

Strings such as `ABC_Test` and `ABC_DEF_Test` were incorrectly getting converted to `ab_c_test` and `ab_c_de_f_test`.

The check was doing `!char.IsUpper(nextChar)` which was also matching on other characters which is why the additional `_` check was needed. 

Changing this to `char.IsLower(nextChar)` copes with all test cases.